### PR TITLE
[BUG] two methods with same name

### DIFF
--- a/lib/chef-umami/test/integration.rb
+++ b/lib/chef-umami/test/integration.rb
@@ -35,12 +35,12 @@ module Umami
         "inspec"
       end
 
-      def test_file(cookbook = '', recipe = '')
+      def test_file_path(cookbook = '', recipe = '')
         "#{test_root}/#{cookbook}_#{recipe}_spec.rb"
       end
 
       def preamble(cookbook = '', recipe = '')
-        "# #{test_file(cookbook, recipe)} - Originally written by Umami!"
+        "# #{test_file_path(cookbook, recipe)} - Originally written by Umami!"
       end
 
       # Call on the apprpriate method from the Umami::Helper::InSpec
@@ -73,7 +73,7 @@ module Umami
           resources.each do |resource|
             content << write_test(resource)
           end
-          test_file_name = test_file(cookbook, recipe)
+          test_file_name = test_file_path(cookbook, recipe)
           test_file_content = content.join("\n") + "\n"
           write_file(test_file_name, test_file_content)
           test_files_written << test_file_name


### PR DESCRIPTION
found out two methods with the same name(test_file()).
one in lib/chef-umami/test/integration.rb
and another in lib/chef-umami/helpers/inspec.rb

in integration.rb#53 it's trying to call method: test_file(),
Two methods with the same name causes the confusion.

Signed-off-by: Yichen Cao <contact@harrycao.info>